### PR TITLE
Add nodemon as a dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "helmet": "^2.2.0",
     "jade": "~1.11.0",
     "morgan": "~1.7.0",
+    "nodemon": "^1.11.0",
     "serve-favicon": "~2.3.0"
   }
 }


### PR DESCRIPTION
This avoids installing nodemon globally.