### PR TITLE
Fix severe vulnerability - malicious package flatmap-stream removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "helmet": "^2.2.0",
     "jade": "~1.11.0",
     "morgan": "~1.7.0",
-    "nodemon": "^1.11.0",
+    "nodemon": "^1.18.7",
     "serve-favicon": "~2.3.0"
   }
 }


### PR DESCRIPTION
As I was filling out another issue (#10) outlining a version upgrade from Jade to Pug, I realized that this project's dependencies had not been updated in some time.

There is a [well known](https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident) vulnerability in the package flatmap-stream, which was a subdependency of nodemon up until version 1.18.7. You can review the conversation regarding updating it on GitHub [here](https://github.com/remy/nodemon/issues/1451). I know the malicious package has been removed from npm, but I'm unsure to what extent it still affects those attempting to install old versions.

This pull request simply upgrades the nodemon package to the most recent version (1.18.7), which no longer uses the malicious package. All previous functionality remains intact.

Note that I'm also happy to submit an additional pr with my upgrade from #10, and any other needed packages.